### PR TITLE
Fix wordcloud

### DIFF
--- a/nlplot/nlplot.py
+++ b/nlplot/nlplot.py
@@ -10,6 +10,7 @@ from collections import defaultdict, Counter
 from tqdm import tqdm
 from sklearn import preprocessing
 import datetime as datetime
+import itertools
 import warnings
 warnings.filterwarnings('ignore')
 warnings.simplefilter('ignore')
@@ -339,7 +340,7 @@ class NLPlot():
                         collocations=False,
                         prefer_horizontal=1,
                         colormap=colormap)
-        wordcloud.generate(str(text))
+        wordcloud.generate(' '.join(list(itertools.chain(*list(text)))))
 
         def show_array(img):
             stream = BytesIO()


### PR DESCRIPTION
Thanks for publishing a great NLP tool. This PR fixes a bug in wordcloud function.

The following figure shows the result of wordcloud, and we can see that there are unexpected words like `Name`, `dtype`, etc.

![image](https://user-images.githubusercontent.com/31459778/82173246-75e53d80-9907-11ea-9b73-b8ba168ca97b.png)

This is because unexpected words are generated when converting pd.Series to str [at this line](https://github.com/takapy0210/nlplot/blob/master/nlplot/nlplot.py#L342). Desirable way of converting is shown as follows.

<img width="1108" alt="Screen Shot 2020-05-18 at 12 54 13" src="https://user-images.githubusercontent.com/31459778/82173456-4420a680-9908-11ea-964d-00a238e84d3c.png">

The following figure is drawn by fixed version nlplot.

![image](https://user-images.githubusercontent.com/31459778/82173689-1d16a480-9909-11ea-8e01-81c070aadc4d.png)

Thanks.

Appendix:
`sum(list, [])` is a simple way for flattening list data, but using `itertools.chain` is faster. (See [comparison](https://twitter.com/maspy_stars/status/1250028585617739777?s=20))