### PR TITLE
#4 Fixed a bug that prevented importing in normal python environment

### DIFF
--- a/nlplot/nlplot.py
+++ b/nlplot/nlplot.py
@@ -17,7 +17,6 @@ warnings.simplefilter('ignore')
 
 import gensim
 import pyLDAvis.gensim
-pyLDAvis.enable_notebook()
 
 import seaborn as sns
 import plotly


### PR DESCRIPTION
## Overview.

Fixed that importing in normal python environment doesn't result in an error.

If you want to display pyLDAvis from notebook environment, you need to import the following library and run it.

```python
import pyLDAvis
pyLDAvis.enable_notebook()
npt.ldavis(num_topics=5, passes=5, save=False)
```