### PR TITLE
Remove duplicate of itertools import

### DIFF
--- a/nlplot/nlplot.py
+++ b/nlplot/nlplot.py
@@ -10,7 +10,6 @@ from collections import defaultdict, Counter
 from tqdm import tqdm
 from sklearn import preprocessing
 import datetime as datetime
-import itertools
 import warnings
 warnings.filterwarnings('ignore')
 warnings.simplefilter('ignore')


### PR DESCRIPTION
Sorry, I added import of itertools by mistake in the [previous PR](https://github.com/takapy0210/nlplot/pull/3/files). This PR removes the duplicate.