### PR TITLE
wordcloudの保存場所・ファイル名を他に統一

### DIFF
--- a/nlplot/nlplot.py
+++ b/nlplot/nlplot.py
@@ -368,7 +368,9 @@ class NLPlot():
         def show_array(img):
             stream = BytesIO()
             if save:
-                Image.fromarray(img).save(self.output_file_path + 'wordcloud.png')
+                date = str(pd.to_datetime(datetime.datetime.now())).split(' ')[0]
+                filename = date + '_wordcloud.png'
+                Image.fromarray(img).save(self.output_file_path + filename)
             Image.fromarray(img).save(stream, 'png')
             IPython.display.display(IPython.display.
                                     Image(data=stream.getvalue()))

--- a/nlplot/nlplot.py
+++ b/nlplot/nlplot.py
@@ -368,7 +368,7 @@ class NLPlot():
         def show_array(img):
             stream = BytesIO()
             if save:
-                Image.fromarray(img).save(self.output_file_path + 'wordcloud.png''wordcloud.png')
+                Image.fromarray(img).save(self.output_file_path + 'wordcloud.png')
             Image.fromarray(img).save(stream, 'png')
             IPython.display.display(IPython.display.
                                     Image(data=stream.getvalue()))

--- a/nlplot/nlplot.py
+++ b/nlplot/nlplot.py
@@ -368,7 +368,7 @@ class NLPlot():
         def show_array(img):
             stream = BytesIO()
             if save:
-                Image.fromarray(img).save('wordcloud.png')
+                Image.fromarray(img).save(self.output_file_path + 'wordcloud.png''wordcloud.png')
             Image.fromarray(img).save(stream, 'png')
             IPython.display.display(IPython.display.
                                     Image(data=stream.getvalue()))


### PR DESCRIPTION
wordcloudの保存場所・ファイル名を他の図表の保管と同じ場所、ファイル名フォーマットにした。